### PR TITLE
fix: replace dialog mode in dashboard with native plugin buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@coongro/consultations": "*"
+    "@coongro/consultations": "*",
+    "@coongro/patients": "*"
   },
   "peerDependencies": {
     "@coongro/plugin-sdk": ">=0.13.0"

--- a/src/views/dashboard/index.tsx
+++ b/src/views/dashboard/index.tsx
@@ -1,3 +1,5 @@
+import { CreateConsultationButton } from '@coongro/consultations';
+import { CreatePetButton } from '@coongro/patients';
 import {
   getHostReact,
   getHostUI,
@@ -351,22 +353,15 @@ export function DashboardView(): React.ReactNode {
       h(
         'div',
         { style: { display: 'flex', gap: '8px' } },
-        h(
-          UI.Button,
-          { size: 'sm', onClick: () => views.open('consultations.form.open', {}, { mode: 'dialog', size: 'xl' }) },
-          h(UI.DynamicIcon, { icon: 'Plus', size: 14 }),
-          ' Nueva Consulta'
-        ),
-        h(
-          UI.Button,
-          {
-            variant: 'outline',
-            size: 'sm',
-            onClick: () => views.open('patients.create.open', {}, { mode: 'dialog', size: 'xl' }),
-          },
-          h(UI.DynamicIcon, { icon: 'Plus', size: 14 }),
-          ' Registrar Paciente'
-        )
+        h(CreateConsultationButton, {
+          label: 'Nueva Consulta',
+          onSuccess: (c) => views.open('consultations.detail.open', { consultationId: c.id }),
+        }),
+        h(CreatePetButton, {
+          label: 'Registrar Paciente',
+          variant: 'outline',
+          onSuccess: (pet) => views.open('patients.detail.open', { petId: pet.id }),
+        })
       )
     ),
 
@@ -486,7 +481,7 @@ function renderTodayConsultations(
                   {
                     key: c.id,
                     onClick: () =>
-                      views.open('consultations.detail.open', { consultationId: c.id }, { mode: 'dialog', size: 'xl' }),
+                      views.open('consultations.detail.open', { consultationId: c.id }),
                     style: { cursor: 'pointer' },
                   },
                   h(
@@ -550,7 +545,7 @@ function renderFollowUpItem(
     'div',
     {
       key: c.id,
-      onClick: () => views.open('consultations.detail.open', { consultationId: c.id }, { mode: 'dialog', size: 'xl' }),
+      onClick: () => views.open('consultations.detail.open', { consultationId: c.id }),
       style: {
         padding: '10px 12px',
         borderRadius: '8px',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,12 @@
       ],
       "@coongro/ui-components": [
         "../../packages/ui-components/dist/index.d.ts"
+      ],
+      "@coongro/consultations": [
+        "../consultations/dist/index.d.ts"
+      ],
+      "@coongro/patients": [
+        "../patients/dist/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
Closes #1

## Changes
- Replace `views.open('consultations.form.open', {}, { mode: 'dialog' })` with `CreateConsultationButton` from `@coongro/consultations`
- Replace `views.open('patients.form.open', {}, { mode: 'dialog' })` with `CreatePetButton` from `@coongro/patients`
- Table row clicks now do simple navigation (no dialog mode)
- Add `@coongro/patients` to `package.json` dependencies
- Add tsconfig paths for `@coongro/consultations` and `@coongro/patients`

## Testing
- [ ] "Nueva Consulta" en dashboard abre FormDialog con PetPicker
- [ ] "Registrar Paciente" en dashboard abre FormDialog con PetForm  
- [ ] Al guardar, navega al detalle del recurso creado
- [ ] Click en fila de consulta navega a detalle de consulta
- [ ] Click en fila de mascota navega a detalle de mascota
- [ ] Build pasa sin errores: `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dedicated buttons for creating consultations and registering patients with streamlined navigation.

* **Improvements**
  * Simplified navigation flow: consultations and follow-up items now open detail views directly instead of modal dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->