### PR TITLE
fix(ci): add contents:read permission for private repo checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [develop, staging, main]
 
 permissions:
+  contents: read
   pull-requests: read
 
 jobs:


### PR DESCRIPTION
Fix CI checkout failure in private repos by adding missing contents:read permission.