### PR TITLE
chore: declare @coongro/vet-staff as kit dependency

### DIFF
--- a/.changeset/declare-vet-staff-dep.md
+++ b/.changeset/declare-vet-staff-dep.md
@@ -1,0 +1,5 @@
+---
+"@coongro/kit-veterinary": patch
+---
+
+Declare `@coongro/vet-staff` as a kit dependency so tenants installing the veterinary kit get the vet professionals module automatically. Also normalizes version constraints for `consultations` and `patients` (removes loose `*`).

--- a/package.json
+++ b/package.json
@@ -45,8 +45,9 @@
   "dependencies": {
     "@coongro/appointments": ">=0.1.0",
     "@coongro/calendar": ">=0.1.0",
-    "@coongro/consultations": "*",
-    "@coongro/patients": "*"
+    "@coongro/consultations": ">=0.1.0",
+    "@coongro/patients": ">=1.0.0",
+    "@coongro/vet-staff": ">=0.1.0"
   },
   "peerDependencies": {
     "@coongro/datetime": ">=0.24.0",


### PR DESCRIPTION
## Summary

- Adds `@coongro/vet-staff` to the kit's `dependencies` so it cascades on install
- Normalizes `consultations` and `patients` constraints from `*` to `>=X.0.0`

## Context

Part of **COONG-96** — audit of kit-veterinary plugin dependencies. No other plugin pulls `vet-staff` transitively, so without this declaration the veterinary kit installs without the vet professionals module.

Companion PR in `Coongro/vet-staff` (already merged) removed a redundant `contacts` declaration.

## Test plan

- [x] Published locally to Verdaccio (same version 0.1.3)
- [x] Clean tenant install cascades vet-staff correctly along with the rest of the kit
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)