### PR TITLE
release: promote develop to staging

### DIFF
--- a/.changeset/declare-vet-staff-dep.md
+++ b/.changeset/declare-vet-staff-dep.md
@@ -1,0 +1,5 @@
+---
+"@coongro/kit-veterinary": patch
+---
+
+Declare `@coongro/vet-staff` as a kit dependency so tenants installing the veterinary kit get the vet professionals module automatically. Also normalizes version constraints for `consultations` and `patients` (removes loose `*`).

--- a/package.json
+++ b/package.json
@@ -45,8 +45,9 @@
   "dependencies": {
     "@coongro/appointments": ">=0.1.0",
     "@coongro/calendar": ">=0.1.0",
-    "@coongro/consultations": "*",
-    "@coongro/patients": "*"
+    "@coongro/consultations": ">=0.1.0",
+    "@coongro/patients": ">=1.0.0",
+    "@coongro/vet-staff": ">=0.1.0"
   },
   "peerDependencies": {
     "@coongro/datetime": ">=0.24.0",


### PR DESCRIPTION
## Summary

Promotes `develop` to `staging` — includes the COONG-96 dependency fix.

## Changes

- `chore: declare @coongro/vet-staff as kit dependency` (#37) — part of COONG-96

## Test plan

- [x] Merged to develop with all checks green
- [ ] Staging CI checks green
- [ ] Auto-version workflow creates version bump PR on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)