### PR TITLE
fix(dashboard): brand variant + ingresos label width (COONG-112)

### DIFF
--- a/.changeset/dashboard-button-and-ingresos-fix.md
+++ b/.changeset/dashboard-button-and-ingresos-fix.md
@@ -1,0 +1,8 @@
+---
+'@coongro/kit-veterinary': patch
+---
+
+fix(dashboard): brand variant + ingresos label width (COONG-112)
+
+- "Registrar Paciente" button: drop variant='outline' so it matches the brand-yellow style of "Nueva Consulta" next to it.
+- Ingresos card: date label width w-12→w-20 + whitespace-nowrap so dates like "19/4/2026" fit on one line instead of wrapping below the bar.

--- a/.turbo/turbo-build.log
+++ b/.turbo/turbo-build.log
@@ -13,4 +13,4 @@ Browserslist: caniuse-lite is outdated. Please run:
 
 Rebuilding...
 
-Done in 332ms.
+Done in 313ms.

--- a/src/views/dashboard/index.tsx
+++ b/src/views/dashboard/index.tsx
@@ -398,7 +398,6 @@ export function DashboardView(): React.ReactNode {
         }),
         h(CreatePetButton, {
           label: 'Registrar Paciente',
-          variant: 'outline',
           onSuccess: (pet) => views.open('patients.detail.open', { petId: pet.id }),
         })
       )
@@ -680,7 +679,9 @@ function renderRevenueChart(
             { key: d.date, className: 'flex items-center gap-2' },
             h(
               'span',
-              { className: 'w-12 shrink-0 text-right text-xs text-cg-text-muted' },
+              {
+                className: 'w-20 shrink-0 text-right text-xs text-cg-text-muted whitespace-nowrap',
+              },
               d.label
             ),
             h(UI.ProgressBar, {


### PR DESCRIPTION
Fix de COONG-112 que quedó stackeado en branch COONG-100. Re-aplicado desde develop.

## Cambios
- Botón Registrar Paciente: brand (era outline)
- Ingresos card: w-12→w-20 + whitespace-nowrap para que las fechas no se rompan a 2 líneas