### PR TITLE
chore(kit-veterinary): menú Compras→Salidas (COONG-212)

### DIFF
--- a/.changeset/salidas-menu.md
+++ b/.changeset/salidas-menu.md
@@ -1,0 +1,5 @@
+---
+"@coongro/kit-veterinary": patch
+---
+
+El menú reasigna "Salidas" (antes "Compras") del plugin purchases a la sección Dinero.

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -57,7 +57,7 @@
       { "pluginId": "@coongro/billing", "path": "Caja", "section": "principal", "order": 5 },
 
       { "pluginId": "@coongro/purchases", "section": "dinero" },
-      { "pluginId": "@coongro/purchases", "path": "Compras", "section": "dinero", "order": 40 },
+      { "pluginId": "@coongro/purchases", "path": "Salidas", "section": "dinero", "order": 40 },
 
       { "pluginId": "@coongro/vet-staff", "section": "equipo" },
       { "pluginId": "@coongro/vet-staff", "path": "Personal", "section": "equipo", "order": 10 }


### PR DESCRIPTION
Reasigna 'Salidas' (antes 'Compras', plugin purchases) en la sección Dinero del menú. Acompaña la entrega de Salidas en purchases#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)