### PR TITLE
feat(kit-veterinary): sección 'Directorio' (Personal + Proveedores) (COONG-212)

### DIFF
--- a/.changeset/directorio-section.md
+++ b/.changeset/directorio-section.md
@@ -1,0 +1,5 @@
+---
+"@coongro/kit-veterinary": patch
+---
+
+Menú: la sección "Equipo" pasa a llamarse "Directorio" (ahora agrupa Personal + Proveedores, que son maestros/directorios de entidades, no flujos de dinero). Se asigna el ítem "Proveedores" (de purchases) a esa sección.

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -22,7 +22,7 @@
       },
       {
         "id": "equipo",
-        "label": "Equipo",
+        "label": "Directorio",
         "order": 40
       }
     ],
@@ -58,6 +58,7 @@
 
       { "pluginId": "@coongro/purchases", "section": "dinero" },
       { "pluginId": "@coongro/purchases", "path": "Salidas", "section": "dinero", "order": 40 },
+      { "pluginId": "@coongro/purchases", "path": "Proveedores", "section": "equipo", "order": 20 },
 
       { "pluginId": "@coongro/vet-staff", "section": "equipo" },
       { "pluginId": "@coongro/vet-staff", "path": "Personal", "section": "equipo", "order": 10 }


### PR DESCRIPTION
La sección **"Equipo"** pasa a llamarse **"Directorio"**. Razón: ahora agrupa **Personal** (tu equipo interno) + **Proveedores** (externos) — ambos son **maestros/directorios de entidades**, no flujos de dinero. "Equipo" se quedaba corto para los proveedores.

- Renombra la sección `equipo` → label **"Directorio"** (id sin cambiar).
- Asigna el ítem `Proveedores` (de purchases, ahora top-level) a esa sección, junto a Personal.

Pareja con el PR de purchases (Proveedores top-level + Salidas directo).

⏳ Los cambios de menú tardan ~5 min en propagarse en dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)