### PR TITLE
fix(COONG-240): declarar vaccination y vademecum como dependencias

### DIFF
--- a/.changeset/coong-240-declare-labs-deps.md
+++ b/.changeset/coong-240-declare-labs-deps.md
@@ -1,0 +1,5 @@
+---
+"@coongro/kit-veterinary": patch
+---
+
+Declara `@coongro/vaccination` y `@coongro/vademecum` como dependencias. La vista de Lotes ya consumía sus RPCs (`vaccination.catalog.list` y `vademecum.laboratories.list`) para mostrar el laboratorio en el subtítulo del lote, pero al no declararlos no venían con el kit y la feature degradaba en silencio. Ahora instalar el kit veterinario instala también el módulo de vacunación y el maestro de laboratorios (COONG-240).

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "@coongro/consultations": ">=0.1.0",
     "@coongro/patients": ">=1.0.0",
     "@coongro/products": ">=2.0.0",
+    "@coongro/vaccination": ">=1.0.0",
+    "@coongro/vademecum": ">=0.1.2",
     "@coongro/vet-staff": ">=0.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Contexto

COONG-240. La vista de **Lotes** del kit veterinario consume RPCs de `vaccination` y `vademecum` en runtime, pero el kit **no los declaraba** como dependencia. Con degradación silenciosa (`try/catch`), la feature simplemente no aparecía: al instalar el kit, esos plugins no venían y el subtítulo del lote **nunca mostraba el laboratorio**.

## Evidencia

`src/views/lotes/index.tsx:88-104`:
```js
const [details, labs] = await Promise.all([
  actions.execute('vaccination.catalog.list'),      // product_id → laboratory_id
  actions.execute('vademecum.laboratories.list'),   // laboratory_id → name
]);
```
(+ otro consumo de `vaccination` para pacientes con vacunas aplicadas, línea ~84). El cierre transitivo del kit no incluía ninguno de los dos.

## Cambio

`package.json` → `dependencies`:
```jsonc
"@coongro/vaccination": ">=1.0.0",
"@coongro/vademecum": ">=0.1.2"
```
Ambos como deps directas (se usan directo). Changeset `patch`.

**Consecuencia:** instalar el kit veterinario ahora instala el módulo de vacunación (menús Vacunas/Aplicadas/Próximas dosis) + el maestro de laboratorios → el subtítulo del lote resuelve el nombre del laboratorio.

## Pendiente aparte

Evaluar si el kit debería incluir también `vet-pharmacy` (farmacia/recetas) — no hay evidencia de que Lotes lo consuma. Se verá después.

## Prueba

`npm run build` + pre-push en verde. Verificación funcional (lote muestra laboratorio) requiere instalar el kit en un tenant y abrir Lotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)