### PR TITLE
feat(copilot): contexto de negocio veterinario para el Copilot IA + orden de menús

### DIFF
--- a/.changeset/copilot-context-veterinary.md
+++ b/.changeset/copilot-context-veterinary.md
@@ -1,0 +1,9 @@
+---
+'@coongro/kit-veterinary': minor
+---
+
+feat(copilot): declarar contexto de negocio veterinario para el Copilot IA
+
+Agrega `copilot-context.md` (contexto del rubro veterinario) y lo declara en el
+manifest vía `copilotContext: { file }`, para que el Copilot IA lo anexe a su
+prompt base cuando el kit está activo en el tenant.

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -3,6 +3,9 @@
   "version": "0.4.0",
   "apiVersion": "2.0",
   "initView": "kit-veterinary.dashboard.open",
+  "copilotContext": {
+    "file": "copilot-context.md"
+  },
   "assets": {
     "styles": [
       "./dist/assets/tailwind.css"
@@ -32,41 +35,100 @@
       }
     ],
     "menuAssignments": [
-      { "pluginId": "@coongro/patients", "section": "clinica" },
-      { "pluginId": "@coongro/patients", "path": "Pacientes", "section": "clinica", "order": 10 },
-
-      { "pluginId": "@coongro/consultations", "section": "clinica" },
-      { "pluginId": "@coongro/consultations", "path": "Consultas", "section": "clinica", "order": 20 },
+      {
+        "pluginId": "@coongro/patients",
+        "section": "clinica"
+      },
+      {
+        "pluginId": "@coongro/patients",
+        "path": "Pacientes",
+        "section": "clinica",
+        "order": 10
+      },
+      {
+        "pluginId": "@coongro/consultations",
+        "section": "clinica"
+      },
+      {
+        "pluginId": "@coongro/consultations",
+        "path": "Consultas",
+        "section": "clinica",
+        "order": 20
+      },
       {
         "pluginId": "@coongro/consultations",
         "path": "Servicios y Precios",
         "section": "dinero",
         "order": 30
       },
-
-      { "pluginId": "@coongro/vaccination", "section": "clinica" },
-      { "pluginId": "@coongro/vaccination", "path": "Vacunación", "section": "clinica", "order": 30 },
-
-      { "pluginId": "@coongro/vet-pharmacy", "section": "clinica" },
-      { "pluginId": "@coongro/vet-pharmacy", "path": "Farmacia", "section": "clinica", "order": 40 },
-
+      {
+        "pluginId": "@coongro/vaccination",
+        "section": "clinica"
+      },
+      {
+        "pluginId": "@coongro/vaccination",
+        "path": "Vacunación",
+        "section": "clinica",
+        "order": 30
+      },
+      {
+        "pluginId": "@coongro/vet-pharmacy",
+        "section": "clinica"
+      },
+      {
+        "pluginId": "@coongro/vet-pharmacy",
+        "path": "Farmacia",
+        "section": "clinica",
+        "order": 40
+      },
       {
         "pluginId": "@coongro/appointments",
         "path": "Consultas/Agenda",
         "section": "principal",
         "order": 10
       },
-
-      { "pluginId": "@coongro/billing", "section": "dinero" },
-      { "pluginId": "@coongro/billing", "path": "Cobros", "section": "dinero", "order": 10 },
-      { "pluginId": "@coongro/billing", "path": "Caja", "section": "principal", "order": 5 },
-
-      { "pluginId": "@coongro/purchases", "section": "dinero" },
-      { "pluginId": "@coongro/purchases", "path": "Salidas", "section": "dinero", "order": 40 },
-      { "pluginId": "@coongro/purchases", "path": "Proveedores", "section": "equipo", "order": 20 },
-
-      { "pluginId": "@coongro/vet-staff", "section": "equipo" },
-      { "pluginId": "@coongro/vet-staff", "path": "Personal", "section": "equipo", "order": 10 }
+      {
+        "pluginId": "@coongro/billing",
+        "section": "dinero"
+      },
+      {
+        "pluginId": "@coongro/billing",
+        "path": "Cobros",
+        "section": "dinero",
+        "order": 10
+      },
+      {
+        "pluginId": "@coongro/billing",
+        "path": "Caja",
+        "section": "principal",
+        "order": 5
+      },
+      {
+        "pluginId": "@coongro/purchases",
+        "section": "dinero"
+      },
+      {
+        "pluginId": "@coongro/purchases",
+        "path": "Salidas",
+        "section": "dinero",
+        "order": 40
+      },
+      {
+        "pluginId": "@coongro/purchases",
+        "path": "Proveedores",
+        "section": "equipo",
+        "order": 20
+      },
+      {
+        "pluginId": "@coongro/vet-staff",
+        "section": "equipo"
+      },
+      {
+        "pluginId": "@coongro/vet-staff",
+        "path": "Personal",
+        "section": "equipo",
+        "order": 10
+      }
     ],
     "menus": [
       {

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -82,12 +82,6 @@
         "order": 40
       },
       {
-        "pluginId": "@coongro/appointments",
-        "path": "Consultas/Agenda",
-        "section": "principal",
-        "order": 10
-      },
-      {
         "pluginId": "@coongro/billing",
         "section": "dinero"
       },
@@ -96,12 +90,6 @@
         "path": "Cobros",
         "section": "dinero",
         "order": 10
-      },
-      {
-        "pluginId": "@coongro/billing",
-        "path": "Caja",
-        "section": "principal",
-        "order": 5
       },
       {
         "pluginId": "@coongro/purchases",
@@ -128,6 +116,24 @@
         "path": "Personal",
         "section": "equipo",
         "order": 10
+      },
+      {
+        "pluginId": "@coongro/kit-veterinary",
+        "path": "Inicio",
+        "section": "principal",
+        "order": 10
+      },
+      {
+        "pluginId": "@coongro/billing",
+        "path": "Caja",
+        "section": "principal",
+        "order": 20
+      },
+      {
+        "pluginId": "@coongro/appointments",
+        "path": "Consultas/Agenda",
+        "section": "principal",
+        "order": 30
       }
     ],
     "menus": [

--- a/copilot-context.md
+++ b/copilot-context.md
@@ -1,0 +1,56 @@
+<!--
+  Contexto de negocio del Copilot IA para el kit veterinario.
+
+  Esto NO es el protocolo del copiloto (JSON, kinds, navigate, pickers…): eso lo
+  aporta el propio ai-copilot y es genérico. Acá va SOLO el conocimiento del
+  rubro: qué negocio es, qué significan los términos, cuál es el flujo típico.
+  Se ANEXA a la base — mantenelo enfocado en el dominio, no en la mecánica.
+
+  En dev es editable desde /dev/copilot y se guarda de vuelta en este archivo.
+-->
+
+Operás el sistema de una **clínica veterinaria**. Tu usuario es el equipo de la
+veterinaria (veterinarios/as, recepción, encargados/as). Ayudás a registrar y
+consultar la operación diaria del negocio.
+
+## Quién es quién
+
+- **Paciente = un animal** (perro, gato, etc.). No es una persona.
+- **Cliente / dueño / tutor = la persona** responsable del paciente (un contacto).
+  Un dueño puede tener varios pacientes; un paciente pertenece a un dueño.
+- **Profesional / veterinario/a = el miembro del staff** que atiende.
+
+Cuando el objetivo diga "el paciente", "la mascota", "el animal" → es el animal.
+Cuando diga "el cliente", "el dueño", "el tutor" → es la persona/contacto.
+
+## Cómo se organiza el trabajo (secciones del kit)
+
+- **Clínica:** pacientes, sus dueños, las consultas/atenciones y las vacunas.
+- **Inventario:** productos, medicamentos e insumos, con stock y vencimiento.
+  Las vacunas y medicamentos son productos con lote y fecha de vencimiento.
+- **Dinero:** cobros al cliente, caja diaria, proveedores y compras.
+- **Equipo:** el staff de la veterinaria.
+
+## Flujo típico
+
+1. Llega un paciente con su dueño (si no existen, se dan de alta primero el
+   dueño/contacto y luego el paciente asociado).
+2. Se registra una **consulta/atención**: motivo, diagnóstico, indicaciones y,
+   si corresponde, medicación o **vacunación** aplicada.
+3. Las **vacunas** siguen un esquema (dosis y refuerzos con fechas); aplicar una
+   vacuna descuenta stock del inventario.
+4. La atención puede generar un **cobro** al cliente (consulta + productos/
+   medicamentos usados). El cobro se salda por caja (efectivo) u otro medio.
+
+## Al interpretar objetivos
+
+- "Cargar/registrar un paciente nuevo" → alta de animal, eligiendo (o creando) su
+  dueño.
+- "Ponerle una vacuna a …", "vacunar …" → registrar vacunación sobre ese
+  paciente, no crear un producto.
+- "Cobrar …", "pasar a caja" → área de dinero/cobros.
+- "Se está por vencer / sin stock" → inventario (vencimiento y existencias).
+
+No asumas datos clínicos ni precios que el usuario no dio: si falta un dato
+obligatorio del formulario y no está en el objetivo, dejalo para que lo complete
+la persona (o preguntá con un finish si no podés avanzar).

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "files": [
     "dist",
     "assets",
-    "coongro.manifest.json"
+    "coongro.manifest.json",
+    "copilot-context.md"
   ],
   "scripts": {
     "build": "npm run build:css && tsc",


### PR DESCRIPTION
## Contexto

Lado-plugin del **contexto por kit** para el Copilot IA: el kit veterinario declara el conocimiento del rubro para que el Copilot lo anexe a su prompt base cuando está activo en el tenant. (Relacionado con el soporte de contexto por kit del core.)

## Cambios

- **`copilot-context.md`** (nuevo): conocimiento del rubro veterinario (paciente = animal, dueño = persona, flujo típico). Editable desde `/dev/copilot`. Es solo dominio, no la mecánica del copiloto.
- **`coongro.manifest.json`**: nuevo campo `copilotContext: { file: "copilot-context.md" }` + organización de menús del kit (patients/consultations/vaccination → "Clínica"; **"Inicio" fijado primero en "Principal"**, orden Inicio → Caja → Consultas/Agenda).
- **`package.json`**: `copilot-context.md` agregado a `files[]` (se publica con el plugin).
- Changeset `minor`.

## Prueba

`npm run build` + pre-push en verde. Validación funcional del contexto en el Copilot: pendiente de confirmación (feature implementada previamente por el equipo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)