### PR TITLE
fix: rango de dependencia @coongro/products (COONG-244)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@coongro/calendar": ">=0.1.0",
     "@coongro/consultations": ">=0.1.0",
     "@coongro/patients": ">=1.0.0",
-    "@coongro/products": ">=2.0.0",
+    "@coongro/products": ">=1.3.0",
     "@coongro/vaccination": ">=1.0.0",
     "@coongro/vademecum": ">=0.1.2",
     "@coongro/vet-staff": ">=0.1.0"


### PR DESCRIPTION
El kit declaraba `@coongro/products: >=2.0.0`, insatisfacible (products maxea en 1.3.0; sus changesets fueron minor). npm install fallaba con ETARGET → el release no arrancaba. Se baja el floor a `>=1.3.0`. Ver Problema 7. COONG-244