### PR TITLE
feat: instalar billing/purchases/vet-pharmacy con el kit (COONG-244)

### DIFF
--- a/.changeset/declare-money-inventory-deps.md
+++ b/.changeset/declare-money-inventory-deps.md
@@ -1,0 +1,10 @@
+---
+'@coongro/kit-veterinary': minor
+---
+
+feat: instalar billing, purchases y vet-pharmacy con el kit
+
+El dashboard consume `billing.*` y la vista de lotes consume `purchases.*` y
+`vet-pharmacy.*` por RPC. Declararlos como deps los instala transitivamente en el
+tenant, con lo que aparecen sus menus (Caja/Cobros, Salidas/Proveedores, Farmacia) y
+los RPCs dejan de degradar en silencio.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin develop
-          git checkout develop
+          git checkout -f develop
           if git merge origin/staging --no-edit; then
             git push origin develop
             echo "### ✅ develop synced with staging" >> $GITHUB_STEP_SUMMARY

--- a/package.json
+++ b/package.json
@@ -45,12 +45,15 @@
   },
   "dependencies": {
     "@coongro/appointments": ">=0.2.0",
+    "@coongro/billing": ">=0.2.0",
     "@coongro/calendar": ">=0.1.0",
     "@coongro/consultations": ">=0.1.0",
     "@coongro/patients": ">=1.0.0",
     "@coongro/products": ">=1.3.0",
+    "@coongro/purchases": ">=0.2.0",
     "@coongro/vaccination": ">=0.2.0",
     "@coongro/vademecum": ">=0.1.2",
+    "@coongro/vet-pharmacy": ">=1.1.0",
     "@coongro/vet-staff": ">=0.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Qué
El kit declara `@coongro/billing >=0.2.0`, `@coongro/purchases >=0.2.0`, `@coongro/vet-pharmacy >=1.1.0`.

## Por qué (deps limpias y coherentes)
Cada dep está justificada por un consumo RPC real de las **vistas propias del kit**:
- `dashboard` → `billing.accounts.listWithTotals`, `billing.lines.listInRange`
- `lotes` → `purchases.salidas.open`, `purchases.suppliers.list`, `vet-pharmacy.medications.list`

Sin declararlas, esos RPC degradan en silencio (ver runtime_rpc_dep_not_declared) y los menús **Caja/Cobros** (billing), **Salidas/Proveedores** (purchases) y **Farmacia** (vet-pharmacy) no aparecen porque los plugins no se instalan en el tenant. Declarándolas se instalan transitivamente y los menús aparecen.

No se declara `vet-inventory`: el kit no lo consume (su vista de lotes sigue in-house; mover lotes→vet-inventory es COONG-241, aún sin reconciliar).

COONG-244