### PR TITLE
feat: instalar vademecum-senasa (provider SENASA) con el kit (COONG-244)

### DIFF
--- a/.changeset/declare-senasa-provider.md
+++ b/.changeset/declare-senasa-provider.md
@@ -1,0 +1,9 @@
+---
+'@coongro/kit-veterinary': minor
+---
+
+feat: instalar el provider de catalogo SENASA (vademecum-senasa) con el kit
+
+El autofill SENASA (vacunacion) y el catalogo de farmacia llaman vademecum.catalog.*,
+que registra el plugin vademecum-senasa. Declararlo como dep del kit lo instala en el
+tenant y el RPC deja de dar 404 not registered.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@coongro/purchases": ">=0.2.0",
     "@coongro/vaccination": ">=0.2.0",
     "@coongro/vademecum": ">=0.1.2",
+    "@coongro/vademecum-senasa": ">=0.2.0",
     "@coongro/vet-pharmacy": ">=1.1.0",
     "@coongro/vet-staff": ">=0.1.0"
   },


### PR DESCRIPTION
El autofill SENASA (vacunación) y el catálogo de farmacia consumen `vademecum.catalog.*`, que registra el plugin **vademecum-senasa**. Sin instalarlo, ese RPC da 404 y aparece 'No se pudo consultar el vademécum'. El kit (umbrella) lo declara → se instala transitivamente → SENASA anda. COONG-244