### PR TITLE
fix(dashboard): top billed items exclude payable accounts (COONG-249)

### DIFF
--- a/.changeset/dashboard-receivable-only.md
+++ b/.changeset/dashboard-receivable-only.md
@@ -1,0 +1,7 @@
+---
+'@coongro/kit-veterinary': patch
+---
+
+fix(dashboard): "Servicios Más Frecuentes" excluye las salidas (COONG-249)
+
+Las cuentas por pagar del ledger (pagos a proveedores, retiros) aparecían como servicios facturados en el top del dashboard. Ahora se pide `billing.lines.listInRange` con `direction: 'receivable'` y se filtra defensivamente `account_direction` del lado cliente para versiones viejas de billing que ignoran el parámetro.

--- a/src/views/dashboard/index.tsx
+++ b/src/views/dashboard/index.tsx
@@ -92,6 +92,8 @@ interface BillingLine {
   subtotal: string;
   source_type: string;
   account_source: string;
+  /** 'receivable' cobros | 'payable' salidas. Ausente en billing viejos. */
+  account_direction?: string;
   opened_at: string;
 }
 
@@ -300,13 +302,20 @@ export function DashboardView(): React.ReactNode {
         // Cobros (billing): fuente de ingresos si el plugin está instalado. Dependencia
         // blanda — si no está, el dashboard sigue calculando desde consultation_services.
         try {
+          // Solo cuentas de COBRO: sin el filtro, las salidas (payable) aparecían como
+          // "servicios más frecuentes" (COONG-249). El filtro cliente cubre billing viejos
+          // que ignoran el param `direction`.
           const [accts, lines] = await Promise.all([
             actions.execute<BillingAccount[]>('billing.accounts.listWithTotals'),
-            actions.execute<BillingLine[]>('billing.lines.listInRange'),
+            actions.execute<BillingLine[]>('billing.lines.listInRange', {
+              direction: 'receivable',
+            }),
           ]);
           if (!cancelled) {
             setBillingAccounts(Array.isArray(accts) ? accts : []);
-            setBillingLines(Array.isArray(lines) ? lines : []);
+            setBillingLines(
+              (Array.isArray(lines) ? lines : []).filter((l) => l.account_direction !== 'payable')
+            );
             setBillingOn(true);
           }
         } catch {


### PR DESCRIPTION
Work item: COONG-249

## Cambios
- "Servicios Más Frecuentes" ya no lista salidas del ledger ("Retiro", "Pago proveedor") como servicios facturados: se pide `billing.lines.listInRange` con `direction: 'receivable'` + filtro defensivo client-side de `account_direction` para billing viejos que ignoran el parámetro.

Depende de Coongro/billing#13 para el filtro server-side (sin él, degrada al comportamiento actual sin romper).

## Testing
- Prueba local: ✅ en vivo — con datos sembrados que incluían "Retiro de la dueña" $20.000 y "Pago proveedor Holliday" $9.000, el top pasó de listarlos como servicios a mostrar solo ítems cobrados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)