### PR TITLE
feat(menus): reubicar Inventario/Insumos (COONG-263)

### DIFF
--- a/.changeset/insumos-menu-inventario.md
+++ b/.changeset/insumos-menu-inventario.md
@@ -2,6 +2,10 @@
 '@coongro/kit-veterinary': minor
 ---
 
-feat(menus): ubica «Insumos» en la sección Inventario (COONG-256)
+feat(menus): inventario unificado — reordena los menús de stock (COONG-263)
 
-Asigna el menú `Insumos` de `vet-inventory` a la sección **inventario**, con `order: 20` (después de "Lotes y stock"). Sin la asignación, un menú nuevo que el kit no conoce queda flotando arriba de todo, fuera de sus secciones.
+El kit ahora asigna los menús de `vet-inventory` así:
+- **Inventario** (antes "Lotes y stock"): sección `inventario`, order 10. Compone perecederos + insumos en una sola pantalla.
+- **Insumos** (catálogo de insumos): pasa a la sección `clinica`, order 60, junto a Pacientes/Consultas/Vacunación/Farmacia — es un catálogo, no una vista de stock.
+
+Sin esta asignación, los menús nuevos/renombrados de `vet-inventory` quedarían flotando fuera de sus secciones.

--- a/.changeset/insumos-menu-inventario.md
+++ b/.changeset/insumos-menu-inventario.md
@@ -1,0 +1,7 @@
+---
+'@coongro/kit-veterinary': minor
+---
+
+feat(menus): ubica «Insumos» en la sección Inventario (COONG-256)
+
+Asigna el menú `Insumos` de `vet-inventory` a la sección **inventario**, con `order: 20` (después de "Lotes y stock"). Sin la asignación, un menú nuevo que el kit no conoce queda flotando arriba de todo, fuera de sus secciones.

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -125,15 +125,15 @@
       },
       {
         "pluginId": "@coongro/vet-inventory",
-        "path": "Lotes y stock",
+        "path": "Inventario",
         "section": "inventario",
         "order": 10
       },
       {
         "pluginId": "@coongro/vet-inventory",
         "path": "Insumos",
-        "section": "inventario",
-        "order": 20
+        "section": "clinica",
+        "order": 60
       },
       {
         "pluginId": "@coongro/vademecum",

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -130,6 +130,12 @@
         "order": 10
       },
       {
+        "pluginId": "@coongro/vet-inventory",
+        "path": "Insumos",
+        "section": "inventario",
+        "order": 20
+      },
+      {
         "pluginId": "@coongro/vademecum",
         "path": "Laboratorios",
         "section": "equipo",


### PR DESCRIPTION
## COONG-263 — Reubicación de menús: Inventario e Insumos

Ajuste de `menuAssignments` de `@coongro/vet-inventory` en el kit para reflejar la unificación de inventario:

- "Lotes y stock" → renombrado a **"Inventario"** (sección `inventario`, order 10): ahora es la vista unificada de perecederos + insumos.
- **"Insumos"** se mueve de la sección `inventario` a la sección `clinica` (order 60, después de Farmacia): es el catálogo (alta/edición de insumos), no una vista de stock, y no correspondía convivir con las vistas de inventario.

Sin cambios de código, solo manifest + changeset.

Refs: COONG-263
